### PR TITLE
use latest DaisySP; set correct path to daisysp.h

### DIFF
--- a/plugin/source/PluginProcessor.h
+++ b/plugin/source/PluginProcessor.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <juce_audio_processors/juce_audio_processors.h>
-#include "../DaisySP/daisysp.h"
+#include "../DaisySP/Source/daisysp.h"
 
 //==============================================================================
 class AudioPluginAudioProcessor : public juce::AudioProcessor


### PR DESCRIPTION
This builds the Standalone and VST3 for me on Linux at least.

It should close https://github.com/electro-smith/Daisy-Juce-Example/issues/2