### PR TITLE
update DaisySP submodule

### DIFF
--- a/plugin/source/PluginProcessor.h
+++ b/plugin/source/PluginProcessor.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <juce_audio_processors/juce_audio_processors.h>
-#include "../DaisySP/daisysp.h"
+#include "daisysp.h"
 
 //==============================================================================
 class AudioPluginAudioProcessor : public juce::AudioProcessor


### PR DESCRIPTION
- this repo doesn't build as at least not on MacOS or Ubuntu 24.04 because of missing CMake entries in the DaisySP submodule
- updating the submodule to the latest commit (as of opening this PR) resolves this issue
- I was able to test building and running the standalone app on MacOS and Ubuntu 24.04


I see another PR from a few years ago doing a similar thing so not sure of the chances of this getting merged in. I found this repo useful to mess around with DaisySP while I wait for the Daisy Seed to come back in stock.